### PR TITLE
Request Performance Improvements

### DIFF
--- a/api.go
+++ b/api.go
@@ -4,12 +4,23 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
+
+	"github.com/hashicorp/go-hclog"
 )
 
 type API struct {
 	BaseUrl string
+	client  *http.Client
+	logger  hclog.Logger
+}
+
+func NewAPI(baseUrl string, logger hclog.Logger) *API {
+	return &API{
+		BaseUrl: baseUrl,
+		client:  http.DefaultClient,
+		logger:  logger,
+	}
 }
 
 func (a *API) Get(path string) (int, []byte) {
@@ -36,14 +47,16 @@ func (a *API) Request(method string, path string, data []byte) (int, []byte) {
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	resp, err := a.client.Do(req)
 	if err != nil {
 		panic(err)
 	}
 	defer resp.Body.Close()
 
 	body, _ := ioutil.ReadAll(resp.Body)
-	log.Println(resp.StatusCode, method, path) //string(body))
+	a.logger.Info("submitted http request",
+		"status_code", resp.StatusCode,
+		"method", method,
+		"path", path)
 	return resp.StatusCode, body
 }

--- a/consul.go
+++ b/consul.go
@@ -31,7 +31,7 @@ type ServiceHealth []struct {
 
 func (c *ConsulAPI) ServiceHealth(name string) bool {
 	var health ServiceHealth
-	path := fmt.Sprintf("/health/service/%s", name)
+	path := fmt.Sprintf("/health/service/%s?stale", name)
 	code, body := c.api.Get(path)
 	if code != 200 {
 		return false

--- a/consul.go
+++ b/consul.go
@@ -5,17 +5,18 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+
+	"github.com/hashicorp/go-hclog"
 )
 
-func NewConsul() *ConsulAPI {
+func NewConsul(logger hclog.Logger) *ConsulAPI {
 	addr := os.Getenv("CONSUL_HTTP_ADDR")
 	if addr == "" {
 		addr = "http://localhost:8500"
 	}
+	api := NewAPI(fmt.Sprintf("%s/v1", addr), logger)
 	return &ConsulAPI{
-		api: &API{
-			BaseUrl: fmt.Sprintf("%s/v1", addr),
-		},
+		api: api,
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -8,6 +8,8 @@ import (
 	"math/rand"
 	"os"
 	"time"
+
+	"github.com/hashicorp/go-hclog"
 )
 
 // 15*16 = 240
@@ -20,7 +22,8 @@ const MaxHeight = 16
 const TmpDir = "/tmp/hgol"
 
 // lazy "global" api clients
-var Consul = NewConsul()
+var logger = hclog.New(nil)
+var Consul = NewConsul(logger)
 var Nomad = NewNomad()
 
 // more lazy globals


### PR DESCRIPTION
This offers mainly two things:
1. Allow stale reads from consul which should be a fair bit more performant.
>stale - This mode allows any server to service the read regardless of whether it is the leader. This means reads can be arbitrarily stale; however, results are generally consistent to within 50 milliseconds of the leader. The trade-off is very fast and scalable reads with a higher likelihood of stale values. Since this mode allows reads without a leader, a cluster that is unavailable will still be able to respond to queries.
2. Reuse a single http client.