### PR TITLE
nomad needs an explicit http client now too

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ const TmpDir = "/tmp/hgol"
 // lazy "global" api clients
 var logger = hclog.New(nil)
 var Consul = NewConsul(logger)
-var Nomad = NewNomad()
+var Nomad = NewNomad(logger)
 
 // more lazy globals
 // var ThisDir, _ = filepath.Abs(filepath.Dir(os.Args[0]))

--- a/nomad.go
+++ b/nomad.go
@@ -5,18 +5,20 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
+
+	"github.com/hashicorp/go-hclog"
 )
 
-func NewNomad() *NomadAPI {
+func NewNomad(logger hclog.Logger) *NomadAPI {
 	addr := os.Getenv("NOMAD_ADDR")
 	if addr == "" {
 		addr = "http://localhost:4646"
 	}
+	api := NewAPI(fmt.Sprintf("%s/v1", addr), logger)
 	return &NomadAPI{
-		api: &API{
-			BaseUrl: fmt.Sprintf("%s/v1", addr),
-		},
+		api: api,
 	}
 }
 


### PR DESCRIPTION
fix so nomad's `API` `client` field isn't a nil pointer, to match previous implementation for consul in #3