### PR TITLE
Consul service discovery for inter-cell UDP traffic

### DIFF
--- a/dns.go
+++ b/dns.go
@@ -28,7 +28,7 @@ type ConsulDNS struct {
 }
 
 func (c *ConsulDNS) GetServiceAddr(serviceName string) (addr string, err error) {
-	name := fmt.Sprintf("%s.service.%s.consul", serviceName, datacenter)
+	name := serviceName + ".service." + datacenter + ".consul"
 
 	_, addrs, err := c.r.LookupSRV(c.ctx, "", "", name)
 	if err != nil {

--- a/dns.go
+++ b/dns.go
@@ -9,8 +9,8 @@ import (
 const consulDnsAddr = "127.0.0.1:8600"
 const datacenter = "dc1"
 
-func NewDNS() *DNSer {
-	return &DNSer{
+func NewConsulDNS() *ConsulDNS {
+	return &ConsulDNS{
 		r: &net.Resolver{
 			PreferGo: true,
 			Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
@@ -22,15 +22,15 @@ func NewDNS() *DNSer {
 	}
 }
 
-type DNSer struct {
+type ConsulDNS struct {
 	r   *net.Resolver
 	ctx context.Context
 }
 
-func (d *DNSer) GetServiceAddr(serviceName string) (addr string, err error) {
+func (c *ConsulDNS) GetServiceAddr(serviceName string) (addr string, err error) {
 	name := fmt.Sprintf("%s.service.%s.consul", serviceName, datacenter)
 
-	_, addrs, err := d.r.LookupSRV(d.ctx, "", "", name)
+	_, addrs, err := c.r.LookupSRV(c.ctx, "", "", name)
 	if err != nil {
 		return "", err
 	}
@@ -42,7 +42,7 @@ func (d *DNSer) GetServiceAddr(serviceName string) (addr string, err error) {
 	target := addrs[0].Target
 	port := addrs[0].Port
 
-	ips, err := d.r.LookupHost(d.ctx, target)
+	ips, err := c.r.LookupHost(c.ctx, target)
 	if err != nil {
 		return "", err
 	}

--- a/dns.go
+++ b/dns.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+)
+
+const consulDnsAddr = "127.0.0.1:8600"
+const datacenter = "dc1"
+
+func NewDNS() *DNSer {
+	return &DNSer{
+		r: &net.Resolver{
+			PreferGo: true,
+			Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+				d := net.Dialer{}
+				return d.DialContext(ctx, "udp", consulDnsAddr)
+			},
+		},
+		ctx: context.Background(),
+	}
+}
+
+type DNSer struct {
+	r   *net.Resolver
+	ctx context.Context
+}
+
+func (d *DNSer) GetServiceAddr(serviceName string) (addr string, err error) {
+	name := fmt.Sprintf("%s.service.%s.consul", serviceName, datacenter)
+
+	_, addrs, err := d.r.LookupSRV(d.ctx, "", "", name)
+	if err != nil {
+		return "", err
+	}
+	if len(addrs) < 1 {
+		return "", fmt.Errorf("%s: got no addrs :(", name)
+	}
+
+	// there should be only one addr in our case.
+	target := addrs[0].Target
+	port := addrs[0].Port
+
+	ips, err := d.r.LookupHost(d.ctx, target)
+	if err != nil {
+		return "", err
+	}
+	if len(ips) < 1 {
+		return "", fmt.Errorf("%s: got no ips :(", target)
+	}
+
+	return fmt.Sprintf("%s:%d", ips[0], port), nil
+}

--- a/dns.go
+++ b/dns.go
@@ -32,7 +32,7 @@ func (c *ConsulDNS) GetServiceAddr(serviceName string) (addr string, err error) 
 
 	_, addrs, err := c.r.LookupSRV(c.ctx, "", "", name)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("Error getting SRV record for %s: %w", name, err)
 	}
 	if len(addrs) < 1 {
 		return "", fmt.Errorf("%s: got no addrs :(", name)
@@ -44,7 +44,7 @@ func (c *ConsulDNS) GetServiceAddr(serviceName string) (addr string, err error) 
 
 	ips, err := c.r.LookupHost(c.ctx, target)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("Error looking up host for %s: %w", target, err)
 	}
 	if len(ips) < 1 {
 		return "", fmt.Errorf("%s: got no ips :(", target)

--- a/main.go
+++ b/main.go
@@ -68,12 +68,13 @@ func main() {
 		Reset()
 
 	case "dnstest": // TODO: remove me
-		d := NewDNS()
-		addr, err := d.GetServiceAddr("api")
+		c := NewConsulDNS()
+		svc := "0-0"
+		addr, err := c.GetServiceAddr(svc)
 		if err != nil {
 			panic(err)
 		}
-		fmt.Println(addr)
+		fmt.Println(svc, addr)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -67,6 +67,13 @@ func main() {
 	case "more":
 		Reset()
 
+	case "dnstest": // TODO: remove me
+		d := NewDNS()
+		addr, err := d.GetServiceAddr("api")
+		if err != nil {
+			panic(err)
+		}
+		fmt.Println(addr)
 	}
 }
 

--- a/nomad.go
+++ b/nomad.go
@@ -64,11 +64,17 @@ type NomadJob struct {
 					CPU      int `json:"CPU"`
 					MemoryMB int `json:"MemoryMB"`
 					DiskMB   int `json:"DiskMB"`
+					Networks []struct {
+						DynamicPorts []struct {
+							Label string `json:"Label"`
+						} `json:"DynamicPorts"`
+					} `json:"Networks"`
 				} `json:"Resources"`
 				Services []struct {
-					Name   string   `json:"Name"`
-					Tags   []string `json:"Tags"`
-					Checks []struct {
+					Name      string   `json:"Name"`
+					PortLabel string   `json:"PortLabel"`
+					Tags      []string `json:"Tags"`
+					Checks    []struct {
 						Name          string   `json:"Name"`
 						Type          string   `json:"Type"`
 						Command       string   `json:"Command"`
@@ -108,10 +114,16 @@ var DefaultJob = fmt.Sprintf(`{
 			  "Resources": {
 				"CPU": 60,
 				"MemoryMB": 35,
-				"DiskMB": 10
+				"DiskMB": 10,
+				"Networks": [{
+					"DynamicPorts": [{
+						"Label": "udp"
+					}]
+				}]
 			  },
 			  "Services": [{
 				  "Name": "0-0",
+				  "PortLabel": "udp",
 				  "Checks": [{
 					  "Name": "check",
 					  "Type": "script",

--- a/nomad.go
+++ b/nomad.go
@@ -5,7 +5,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/hashicorp/go-hclog"


### PR DESCRIPTION
To enable future communication between cells, add a dynamic "udp" port to each cell job, and a little DNS resolver client for getting `host:port` for services by name from Consul.

Nomad will expose an environment variable `NOMAD_PORT_udp` for the cells to listen on.